### PR TITLE
Add ClientCertificates

### DIFF
--- a/src/EasyHttp/Http/HttpClient.cs
+++ b/src/EasyHttp/Http/HttpClient.cs
@@ -58,6 +58,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using EasyHttp.Codecs;
 using EasyHttp.Configuration;
@@ -211,7 +212,13 @@ namespace EasyHttp.Http
             return Response;
         }
 
-       
+        public void AddClientCertificates(X509CertificateCollection certificates)
+        {
+            if(certificates == null || certificates.Count == 0)
+                return;
+
+            Request.ClientCertificates.AddRange(certificates);
+        }
 
         bool IsHttpError()
         {

--- a/src/EasyHttp/Http/HttpRequest.cs
+++ b/src/EasyHttp/Http/HttpRequest.cs
@@ -125,7 +125,9 @@ namespace EasyHttp.Http
         public HttpRequest(IEncoder encoder)
         {
             RawHeaders = new Dictionary<string, object>();
-            
+
+            ClientCertificates = new X509CertificateCollection();
+
             UserAgent = String.Format("EasyHttp HttpClient v{0}",
                                        Assembly.GetAssembly(typeof(HttpClient)).GetName().Version);
 
@@ -367,8 +369,7 @@ namespace EasyHttp.Http
             if (ClientCertificates == null || ClientCertificates.Count == 0)
                 return;
 
-            foreach (var cert in ClientCertificates)
-                httpWebRequest.ClientCertificates.Add(cert);
+            httpWebRequest.ClientCertificates.AddRange(ClientCertificates);
         }
 
         void SetupAuthentication()


### PR DESCRIPTION
Some services require an X509 Certificate for access.
