### PR TITLE
Feature: Allow the automatic following of redirects to be turned off.

### DIFF
--- a/src/EasyHttp.Specs/EasyHttp.Specs.csproj
+++ b/src/EasyHttp.Specs/EasyHttp.Specs.csproj
@@ -92,6 +92,7 @@
     <Compile Include="BugRepros\UploadFileIssue.cs" />
     <Compile Include="Helpers\DataSpecificationBase.cs" />
     <Compile Include="Helpers\ServiceStackHost.cs" />
+    <Compile Include="Specs\AutoFollowRedirectSpecs.cs" />
     <Compile Include="Specs\DynamicObjectToUrlSegmentsSpecs.cs" />
     <Compile Include="Specs\DynamicObjectToUrlSpecs.cs" />
     <Compile Include="Specs\HttpErrorHandlingSpecs.cs" />

--- a/src/EasyHttp.Specs/Helpers/ServiceStackHost.cs
+++ b/src/EasyHttp.Specs/Helpers/ServiceStackHost.cs
@@ -15,6 +15,11 @@ namespace EasyHttp.Specs.Helpers
         public string Result { get; set; }
     }
 
+    public class Redirect
+    {
+        public string Name { get; set; }
+    }
+
     public class Files
     {
         public string Name { get; set; }
@@ -80,6 +85,21 @@ namespace EasyHttp.Specs.Helpers
         }
     }
 
+    public class RedirectorService : RestServiceBase<Redirect>
+    {
+        public override object OnGet(Redirect request)
+        {
+            if (this.Request.AbsoluteUri.EndsWith("redirected"))
+                return new HttpResult() { StatusCode = HttpStatusCode.OK, };
+
+            return new HttpResult()
+                   {
+                       StatusCode = HttpStatusCode.Redirect,
+                       Location = this.Request.AbsoluteUri+"/redirected"
+                   };
+        }
+    }
+
     //Define the Web Services AppHost
     public class ServiceStackHost : AppHostHttpListenerBase
     {
@@ -87,11 +107,14 @@ namespace EasyHttp.Specs.Helpers
 
         public override void Configure(Funq.Container container)
         {
-            Routes
-                            .Add<Hello>("/hello")
-                            .Add<Hello>("/hello/{Name}");
-            Routes.Add<Files>("/fileupload/{Name}").Add<Files>("/fileupload");
-            Routes.Add<CookieInfo>("/cookie").Add<CookieInfo>("/cookie/{Name}");
+            Routes.Add<Hello>("/hello")
+                  .Add<Hello>("/hello/{Name}");
+            Routes.Add<Files>("/fileupload/{Name}")
+                  .Add<Files>("/fileupload");
+            Routes.Add<CookieInfo>("/cookie")
+                  .Add<CookieInfo>("/cookie/{Name}");
+            Routes.Add<Redirect>("/redirector")
+                  .Add<Redirect>("/redirector/redirected");
         }
     }
 }

--- a/src/EasyHttp.Specs/Specs/AutoFollowRedirectSpecs.cs
+++ b/src/EasyHttp.Specs/Specs/AutoFollowRedirectSpecs.cs
@@ -1,0 +1,43 @@
+﻿using System.Net;
+using EasyHttp.Http;
+using Machine.Specifications;
+
+namespace EasyHttp.Specs.Specs
+{
+    public class AutoFollowRedirectSpecs
+    {
+        [Subject("HttpClient")]
+        public class when_making_a_GET_request_with_AutoRedirect_on
+        {
+            private Establish context = () => { httpClient = new HttpClient(); };
+
+            private Because of = () => httpClient.Get("http://localhost:16000/redirector");
+
+            private It should_return_status_code_of_OK =
+                () => httpClient.Response.StatusCode.ShouldEqual(HttpStatusCode.OK);
+
+            private It should_redirect = () => httpClient.Response.Location.ShouldBeEmpty();
+
+            private static HttpClient httpClient;
+        }
+
+        [Subject("HttpClient")]
+        public class when_making_a_GET_request_with_AutoRedirect_off
+        {
+            private Establish context = () => { httpClient = new HttpClient(); };
+
+            private Because of = () =>
+            {
+                httpClient.Request.AllowAutoRedirect = false;
+                httpClient.Get("http://localhost:16000/redirector");
+            };
+
+            private It should_return_status_code_of_Redirect =
+                () => httpClient.Response.StatusCode.ShouldEqual(HttpStatusCode.Redirect);
+
+            private It should_redirect = () => httpClient.Response.Location.ShouldEndWith("redirected");
+
+            private static HttpClient httpClient;
+        }
+    }
+}

--- a/src/EasyHttp/Http/HttpRequest.cs
+++ b/src/EasyHttp/Http/HttpRequest.cs
@@ -70,6 +70,8 @@ namespace EasyHttp.Http
             _encoder = encoder;
 
             Timeout = 100000; //http://msdn.microsoft.com/en-us/library/system.net.httpwebrequest.timeout.aspx
+
+            AllowAutoRedirect = true;
         }
 
         public string Accept { get; set; }
@@ -110,7 +112,7 @@ namespace EasyHttp.Http
         }
 
         public bool PersistCookies { get; set; }
-
+        public bool AllowAutoRedirect { get; set; }
 
         public void SetBasicAuthentication(string username, string password)
         {
@@ -279,7 +281,7 @@ namespace EasyHttp.Http
         public HttpWebRequest PrepareRequest()
         {
             httpWebRequest = (HttpWebRequest) WebRequest.Create(Uri);
-
+            httpWebRequest.AllowAutoRedirect = AllowAutoRedirect;
             SetupHeader();
 
             SetupBody();


### PR DESCRIPTION
Currently if EasyHttp makes a request, it'll automatically follow any 302 responses it receives. When using EasyHttp to test a web api it can be usefull to check that it receives a 302 rather than following it.

**Implementation**
EasyHttp uses a HttpWebRequest under the hood, which already has this functionality. The change is to HttpRequest, adding a property "AllowAutoRedirect" with a default value of true (to maintain existing behaviour) which toggles the underlying HttpWebRequest.
