### PR TITLE
Removed set of Content-Encoding on request

### DIFF
--- a/src/EasyHttp/EasyHttp.csproj
+++ b/src/EasyHttp/EasyHttp.csproj
@@ -65,7 +65,7 @@
     <Compile Include="Configuration\IEncoderDecoderConfiguration.cs" />
     <Compile Include="Http\CacheControl.cs" />
     <Compile Include="Http\HttpClient.cs" />
-    <Compile Include="Http\HttpContentEncoding.cs" />
+    <Compile Include="Http\HttpContentTransferEncoding.cs" />
     <Compile Include="Http\HttpContentTypes.cs" />
     <Compile Include="Http\HttpMethod.cs" />
     <Compile Include="Http\HttpRequest.cs" />

--- a/src/EasyHttp/Http/HttpClient.cs
+++ b/src/EasyHttp/Http/HttpClient.cs
@@ -168,7 +168,6 @@ namespace EasyHttp.Http
             {
                 Request.ContentType = contentType;
                 Request.Data = data;
-                Request.ContentEncoding = HttpContentEncoding.Utf8;
             }
         }
 

--- a/src/EasyHttp/Http/HttpContentEncoding.cs
+++ b/src/EasyHttp/Http/HttpContentEncoding.cs
@@ -1,9 +1,0 @@
-﻿namespace EasyHttp.Http
-{
-    public static class HttpContentEncoding
-    {
-        public const string Utf8 = "utf-8";
-        public const string Binary = "binary";
-        public const string Base64 = "base64";
-    }
-}

--- a/src/EasyHttp/Http/HttpContentTransferEncoding.cs
+++ b/src/EasyHttp/Http/HttpContentTransferEncoding.cs
@@ -1,0 +1,11 @@
+﻿namespace EasyHttp.Http
+{
+    public static class HttpContentTransferEncoding
+    {
+        public const string Bit8 = "8bit";
+        public const string Bit7 = "7bit";
+        public const string QuotedPrintable = "quoted-printable";
+        public const string Binary = "binary";
+        public const string Base64 = "base64";
+    }
+}

--- a/src/EasyHttp/Http/MultipartStreamer.cs
+++ b/src/EasyHttp/Http/MultipartStreamer.cs
@@ -60,13 +60,13 @@ namespace EasyHttp.Http
 
             while ((count = file.Read(buffer, 0, buffer.Length)) > 0)
             {
-                if (fileData.ContentTransferEncoding == HttpContentEncoding.Base64)
+                if (fileData.ContentTransferEncoding == HttpContentTransferEncoding.Base64)
                 {
                     string str = Convert.ToBase64String(buffer, 0, count);
 
                     requestStream.WriteString(str);
                 }
-                else if (fileData.ContentTransferEncoding == HttpContentEncoding.Binary)
+                else if (fileData.ContentTransferEncoding == HttpContentTransferEncoding.Binary)
                 {
                     requestStream.Write(buffer, 0, count);
                 }

--- a/src/EasyHttp/Infrastructure/FileData.cs
+++ b/src/EasyHttp/Infrastructure/FileData.cs
@@ -11,7 +11,7 @@ namespace EasyHttp.Infrastructure
 
         public FileData()
         {
-            ContentTransferEncoding = HttpContentEncoding.Binary;
+            ContentTransferEncoding = HttpContentTransferEncoding.Binary;
         }
     }
 }


### PR DESCRIPTION
per http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.5
this should be (identity|deflate|compress|gzip), and identity is the default if not specified.
The HttpContentEncoding class is renamed to HttpContentTransferEncoding and updated with missing values.