### PR TITLE
Add support for default credentials

### DIFF
--- a/src/EasyHttp/Http/HttpRequest.cs
+++ b/src/EasyHttp/Http/HttpRequest.cs
@@ -104,6 +104,7 @@ namespace EasyHttp.Http
         public IList<FileData> MultiPartFileData { get; set; }
         public int Timeout { get; set; }
         public Boolean ParametersAsSegments { get; set; }
+        public bool UseDefaultCredentials { get; set; }
 
         public bool ForceBasicAuth
         {
@@ -307,6 +308,10 @@ namespace EasyHttp.Http
                 string authInfo = _username + ":" + _password;
                 authInfo = Convert.ToBase64String(Encoding.Default.GetBytes(authInfo));
                 httpWebRequest.Headers["Authorization"] = "Basic " + authInfo;
+            }
+            else if (UseDefaultCredentials)
+            {
+                httpWebRequest.UseDefaultCredentials = true;
             }
             else
             {


### PR DESCRIPTION
Hello

This is adding the ability to pass default credentials. This would be really useful for intranet apps with NTML authentication because you don't need to worry about storing/passing credentials.