### PR TITLE
Disable automatic decompression

### DIFF
--- a/src/EasyHttp.Specs/BugRepros/AcceptEncodingIssue.cs
+++ b/src/EasyHttp.Specs/BugRepros/AcceptEncodingIssue.cs
@@ -33,4 +33,36 @@ namespace EasyHttp.Specs.BugRepros
         static HttpClient http;
         private static HttpWebRequest underlyingRequest;
     }
+
+    [Subject("Accept-Encoding")]
+    public class when_disabling_automatic_compression
+    {
+        Establish context = () =>
+        {
+            http = new HttpClient()
+            {
+                Request = {
+                    Uri = "http://github.com/" , // a Uri is required by the PrepareRequest() method
+                    DisableAutomaticCompression = true
+                }
+            };
+        };
+
+        Because of = () =>
+            {
+                underlyingRequest = http.Request.PrepareRequest();
+            };
+
+        It should_disable_automatic_gzip_compression_on_the_underlying_web_request = () =>
+            {
+                underlyingRequest.AutomaticDecompression.ShouldNotHaveFlag(DecompressionMethods.GZip);
+            };
+
+        It should_disable_automatic_deflate_compression_on_the_underlying_web_request = () =>
+            {
+                underlyingRequest.AutomaticDecompression.ShouldNotHaveFlag(DecompressionMethods.Deflate);
+            };
+        static HttpClient http;
+        private static HttpWebRequest underlyingRequest;
+    }
 }

--- a/src/EasyHttp.Specs/BugRepros/AcceptEncodingIssue.cs
+++ b/src/EasyHttp.Specs/BugRepros/AcceptEncodingIssue.cs
@@ -1,0 +1,36 @@
+﻿using System.Net;
+using EasyHttp.Http;
+using EasyHttp.Specs.Helpers;
+using Machine.Specifications;
+
+namespace EasyHttp.Specs.BugRepros
+{
+    [Subject("Accept-Encoding")]
+    public class when_preparing_a_web_request
+    {
+        Establish context = () =>
+        {
+            http = new HttpClient()
+            {
+                Request = { Uri = "http://github.com/" } // a Uri is required by the PrepareRequest() method
+            };
+        };
+
+        Because of = () =>
+            {
+                underlyingRequest = http.Request.PrepareRequest();
+            };
+
+        It should_enable_automatic_gzip_compression_on_the_underlying_web_request_by_default = () =>
+            {
+                underlyingRequest.AutomaticDecompression.ShouldHaveFlag(DecompressionMethods.GZip);
+            };
+
+        It should_enable_automatic_deflate_compression_on_the_underlying_web_request_by_default = () =>
+            {
+                underlyingRequest.AutomaticDecompression.ShouldHaveFlag(DecompressionMethods.Deflate);
+            };
+        static HttpClient http;
+        private static HttpWebRequest underlyingRequest;
+    }
+}

--- a/src/EasyHttp.Specs/EasyHttp.Specs.csproj
+++ b/src/EasyHttp.Specs/EasyHttp.Specs.csproj
@@ -89,7 +89,9 @@
     <Compile Include="BugRepros\CustomPropertyNameIssue.cs" />
     <Compile Include="BugRepros\DecodingIssues.cs" />
     <Compile Include="BugRepros\EnumEncodingIssue.cs" />
+    <Compile Include="Helpers\MSpecFlagAssertions.cs" />
     <Compile Include="BugRepros\UploadFileIssue.cs" />
+    <Compile Include="BugRepros\AcceptEncodingIssue.cs" />
     <Compile Include="Helpers\DataSpecificationBase.cs" />
     <Compile Include="Helpers\ServiceStackHost.cs" />
     <Compile Include="Specs\AutoFollowRedirectSpecs.cs" />

--- a/src/EasyHttp.Specs/Helpers/MSpecFlagAssertions.cs
+++ b/src/EasyHttp.Specs/Helpers/MSpecFlagAssertions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Machine.Specifications;
+using Machine.Specifications.Utility.Internal;
+
+namespace EasyHttp.Specs.Helpers
+{
+    public static class MSpecFlagAssertions
+    {
+        public static Enum ShouldHaveFlag(this Enum actual, Enum expected)
+        {
+            if (!actual.HasFlag(expected))
+                throw new SpecificationException(PrettyPrintingExtensions.FormatErrorMessage((object)actual, (object)expected));
+            return actual;
+        }
+
+        public static Enum ShouldNotHaveFlag(this Enum actual, Enum expected)
+        {
+            if (actual.HasFlag(expected))
+                throw new SpecificationException(string.Format("Should not have {0} set but does: {1}", (object)expected, ((object)actual)));
+            return actual;
+        }
+    }
+}

--- a/src/EasyHttp/Http/HttpRequest.cs
+++ b/src/EasyHttp/Http/HttpRequest.cs
@@ -74,6 +74,7 @@ namespace EasyHttp.Http
             AllowAutoRedirect = true;
         }
 
+        public bool DisableAutomaticCompression { get; set; }
         public string Accept { get; set; }
         public string AcceptCharSet { get; set; }
         public string AcceptEncoding { get; set; }

--- a/src/EasyHttp/Http/HttpRequest.cs
+++ b/src/EasyHttp/Http/HttpRequest.cs
@@ -134,7 +134,9 @@ namespace EasyHttp.Http
             httpWebRequest.Referer = Referer;
             httpWebRequest.CachePolicy = _cachePolicy;
             httpWebRequest.KeepAlive = KeepAlive;
-            httpWebRequest.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip | DecompressionMethods.None;
+            httpWebRequest.AutomaticDecompression = DisableAutomaticCompression
+                                                    ? DecompressionMethods.None
+                                                    : DecompressionMethods.Deflate | DecompressionMethods.GZip | DecompressionMethods.None;
 
             ServicePointManager.Expect100Continue = Expect;
             ServicePointManager.ServerCertificateValidationCallback = AcceptAllCertifications;


### PR DESCRIPTION
I was using `EasyHttp` to submit JSON data to an API via a POST request when I noticed that regardless of what I set as the `AcceptEncoding` parameter of the `Request` object the response was coming back gzip-encoded.

I would set it like this:
````
var http = new HttpClient{
    Request = {
        AcceptEncoding = ""
    }
};
````

and up until the point of calling `Post(...)` the `http.Request.Headers` collection would respect that blank setting.

Fiddler, however, revealed that the actual Accept-Encoding HttpHeader sent by the `HttpClient` was

````
    Accept-Encoding: ,gzip,deflate
````

After a bit of spelunking in the .NET framework I discovered [this code on the underlying `System.Net.HttpWebRequest` class](https://github.com/Microsoft/referencesource/blob/e458f8df6ded689323d4bd1a2a725ad32668aaec/System/net/System/Net/HttpWebRequest.cs#L4982-L4999) which would conditionally add the GZip and Deflate compression headers if the `AutomaticDecompression` `Flags` `Enum` was set to include them.

Turns out the `HttpRequest.PrepareHeaders()` method has been set to [explicitly include them](https://github.com/hhariri/EasyHttp/blob/master/src/EasyHttp/Http/HttpRequest.cs#L136) which seems to be what was causing _my_ explicit setting to be overruled.

In keeping with the "easy" spirit of `EasyHttp` I propose to add a simple `boolean` property to `DisableAutomaticCompression` which I feel is a more intuitive addition to the current behavior, despite reading like the inverse of the underlying `AutomaticDecompression` syntax.