### PR TITLE
add seams for mocking and injecting fake responses

### DIFF
--- a/src/EasyHttp.Specs/BugRepros/AcceptEncodingIssue.cs
+++ b/src/EasyHttp.Specs/BugRepros/AcceptEncodingIssue.cs
@@ -1,7 +1,9 @@
 ﻿using System.Net;
 using EasyHttp.Http;
+using EasyHttp.Http.Abstractions;
 using EasyHttp.Specs.Helpers;
 using Machine.Specifications;
+using ServiceStack.WebHost.Endpoints.Extensions;
 
 namespace EasyHttp.Specs.BugRepros
 {
@@ -18,7 +20,7 @@ namespace EasyHttp.Specs.BugRepros
 
         Because of = () =>
             {
-                underlyingRequest = http.Request.PrepareRequest();
+                underlyingRequest = (http.Request.PrepareRequest() as HttpWebRequestWrapper).InnerRequest;
             };
 
         It should_enable_automatic_gzip_compression_on_the_underlying_web_request_by_default = () =>
@@ -50,7 +52,7 @@ namespace EasyHttp.Specs.BugRepros
 
         Because of = () =>
             {
-                underlyingRequest = http.Request.PrepareRequest();
+                underlyingRequest = (http.Request.PrepareRequest() as HttpWebRequestWrapper).InnerRequest;
             };
 
         It should_disable_automatic_gzip_compression_on_the_underlying_web_request = () =>

--- a/src/EasyHttp.Specs/EasyHttp.Specs.csproj
+++ b/src/EasyHttp.Specs/EasyHttp.Specs.csproj
@@ -48,6 +48,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Machine.Specifications.0.5.10\lib\net40\Machine.Specifications.Clr4.dll</HintPath>
     </Reference>
+    <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.1.10.0.0\lib\net40\NSubstitute.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="ServiceStack">
       <HintPath>..\packages\ServiceStack.3.9.23\lib\net35\ServiceStack.dll</HintPath>
     </Reference>

--- a/src/EasyHttp.Specs/Specs/HttpRequestSpecs.cs
+++ b/src/EasyHttp.Specs/Specs/HttpRequestSpecs.cs
@@ -148,7 +148,7 @@ namespace EasyHttp.Specs.Specs
     }
 
     [Subject("HttpClient")]
-    public class when_mocking_a_GET_request_with_valid_uri_to_return_a_NotFound
+    public class when_injecting_a_single_response_factory_to_return_NotFound
     {
         Establish context = () =>
         {
@@ -162,6 +162,31 @@ namespace EasyHttp.Specs.Specs
         {
             httpResponse = httpClient.Get("http://localhost:16000");
 
+        };
+
+        It should_return_a_NotFound =
+            () => httpResponse.StatusCode.ShouldEqual(HttpStatusCode.NotFound);
+
+
+        static HttpClient httpClient;
+        static HttpResponse httpResponse;
+    }
+
+    [Subject("HttpClient")]
+    public class when_mocking_a_GET_request_with_valid_uri_to_return_a_NotFound
+    {
+        Establish context = () =>
+        {
+            var injectedResponse = Substitute.For<HttpResponse>();
+            injectedResponse.StatusCode.Returns(HttpStatusCode.NotFound);
+
+            httpClient = Substitute.For<HttpClient>();
+            httpClient.Get(Arg.Any<string>()).Returns(injectedResponse);
+        };
+
+        Because of = () =>
+        {
+            httpResponse = httpClient.Get("http://localhost:16000");
         };
 
         It should_return_a_NotFound =

--- a/src/EasyHttp.Specs/Specs/HttpRequestSpecs.cs
+++ b/src/EasyHttp.Specs/Specs/HttpRequestSpecs.cs
@@ -148,31 +148,6 @@ namespace EasyHttp.Specs.Specs
     }
 
     [Subject("HttpClient")]
-    public class when_injecting_a_single_response_factory_to_return_NotFound
-    {
-        Establish context = () =>
-        {
-            var injectedResponse = Substitute.For<HttpResponse>();
-            injectedResponse.StatusCode.Returns(HttpStatusCode.NotFound);
-
-            httpClient = new HttpClient(x => injectedResponse);
-        };
-
-        Because of = () =>
-        {
-            httpResponse = httpClient.Get("http://localhost:16000");
-
-        };
-
-        It should_return_a_NotFound =
-            () => httpResponse.StatusCode.ShouldEqual(HttpStatusCode.NotFound);
-
-
-        static HttpClient httpClient;
-        static HttpResponse httpResponse;
-    }
-
-    [Subject("HttpClient")]
     public class when_mocking_a_GET_request_with_valid_uri_to_return_a_NotFound
     {
         Establish context = () =>

--- a/src/EasyHttp.Specs/Specs/HttpRequestSpecs.cs
+++ b/src/EasyHttp.Specs/Specs/HttpRequestSpecs.cs
@@ -61,6 +61,7 @@ using System.Net;
 using EasyHttp.Http;
 using EasyHttp.Specs.Helpers;
 using Machine.Specifications;
+using NSubstitute;
 using Result = EasyHttp.Specs.Helpers.ResultResponse;
 
 namespace EasyHttp.Specs.Specs
@@ -142,6 +143,31 @@ namespace EasyHttp.Specs.Specs
             () => httpResponse.RawText.ShouldNotBeEmpty();
 
     
+        static HttpClient httpClient;
+        static HttpResponse httpResponse;
+    }
+
+    [Subject("HttpClient")]
+    public class when_mocking_a_GET_request_with_valid_uri_to_return_a_NotFound
+    {
+        Establish context = () =>
+        {
+            var injectedResponse = Substitute.For<HttpResponse>();
+            injectedResponse.StatusCode.Returns(HttpStatusCode.NotFound);
+
+            httpClient = new HttpClient(x => injectedResponse);
+        };
+
+        Because of = () =>
+        {
+            httpResponse = httpClient.Get("http://localhost:16000");
+
+        };
+
+        It should_return_a_NotFound =
+            () => httpResponse.StatusCode.ShouldEqual(HttpStatusCode.NotFound);
+
+
         static HttpClient httpClient;
         static HttpResponse httpResponse;
     }

--- a/src/EasyHttp.Specs/Specs/HttpRequestSpecs.cs
+++ b/src/EasyHttp.Specs/Specs/HttpRequestSpecs.cs
@@ -1,10 +1,10 @@
 ﻿#region License
 // Distributed under the BSD License
 // =================================
-// 
+//
 // Copyright (c) 2010, Hadi Hariri
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
 //     * Redistributions of source code must retain the above copyright
@@ -15,7 +15,7 @@
 //     * Neither the name of Hadi Hariri nor the
 //       names of its contributors may be used to endorse or promote products
 //       derived from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -27,26 +27,26 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // =============================================================
-// 
-// 
+//
+//
 // Parts of this Software use JsonFX Serialization Library which is distributed under the MIT License:
-// 
+//
 // Distributed under the terms of an MIT-style license:
-// 
+//
 // The MIT License
-// 
+//
 // Copyright (c) 2006-2009 Stephen M. McKamey
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -87,7 +87,7 @@ namespace EasyHttp.Specs.Specs
     }
 
     [Subject("HttpClient")]
-    public class when_making_a_DELETE_request_with_a_valid_uri 
+    public class when_making_a_DELETE_request_with_a_valid_uri
     {
         Establish context = () =>
         {
@@ -142,7 +142,7 @@ namespace EasyHttp.Specs.Specs
         It should_return_body_with_rawtext =
             () => httpResponse.RawText.ShouldNotBeEmpty();
 
-    
+
         static HttpClient httpClient;
         static HttpResponse httpResponse;
     }
@@ -328,7 +328,7 @@ namespace EasyHttp.Specs.Specs
         static HttpResponse response;
     }
 
-  
+
     [Subject("HttpClient")]
     public class when_making_a_HEAD_request_with_valid_uri
     {

--- a/src/EasyHttp.Specs/packages.config
+++ b/src/EasyHttp.Specs/packages.config
@@ -3,6 +3,7 @@
   <package id="JsonFx" version="2.0.1209.2802" targetFramework="net40" />
   <package id="Machine.Specifications" version="0.5.7" />
   <package id="Machine.Specifications" version="0.5.10" targetFramework="net40" />
+  <package id="NSubstitute" version="1.10.0.0" targetFramework="net40" />
   <package id="ServiceStack" version="3.9.23" targetFramework="net40" />
   <package id="ServiceStack.Common" version="3.9.21" targetFramework="net40" />
   <package id="ServiceStack.OrmLite.SqlServer" version="3.9.14" targetFramework="net40" />

--- a/src/EasyHttp/EasyHttp.csproj
+++ b/src/EasyHttp/EasyHttp.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Codecs\JsonFXExtensions\UrlEncoderWriter.cs" />
     <Compile Include="Configuration\DefaultEncoderDecoderConfiguration.cs" />
     <Compile Include="Configuration\IEncoderDecoderConfiguration.cs" />
+    <Compile Include="Http\Abstractions\IHttpRequestInterceptionBuilder.cs" />
     <Compile Include="Http\CacheControl.cs" />
     <Compile Include="Http\HttpClient.cs" />
     <Compile Include="Http\HttpContentTransferEncoding.cs" />
@@ -70,7 +71,18 @@
     <Compile Include="Http\HttpMethod.cs" />
     <Compile Include="Http\HttpRequest.cs" />
     <Compile Include="Http\HttpResponse.cs" />
+    <Compile Include="Http\Injection\HttpRequestInterception.cs" />
+    <Compile Include="Http\Abstractions\HttpWebRequestWrapper.cs" />
+    <Compile Include="Http\Abstractions\HttpWebResponseWrapper.cs" />
+    <Compile Include="Http\Abstractions\IHttpRequestInterception.cs" />
+    <Compile Include="Http\Abstractions\IHttpWebRequest.cs" />
+    <Compile Include="Http\Abstractions\IHttpWebResponse.cs" />
+    <Compile Include="Http\Abstractions\IWebResponse.cs" />
     <Compile Include="Http\MultipartStreamer.cs" />
+    <Compile Include="Http\StreamExtensions.cs" />
+    <Compile Include="Http\Injection\StubbedHttpWebRequest.cs" />
+    <Compile Include="Http\Injection\StubbedHttpWebResponse.cs" />
+    <Compile Include="Http\Abstractions\WebResponseWrapper.cs" />
     <Compile Include="Infrastructure\ConfigurationException.cs" />
     <Compile Include="Infrastructure\ObjectToUrl.cs" />
     <Compile Include="Infrastructure\ObjectToUrlSegments.cs" />

--- a/src/EasyHttp/Http/Abstractions/HttpWebRequestWrapper.cs
+++ b/src/EasyHttp/Http/Abstractions/HttpWebRequestWrapper.cs
@@ -1,0 +1,173 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.Net.Cache;
+using System.Net.Security;
+using System.Runtime.Remoting;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Principal;
+
+namespace EasyHttp.Http.Abstractions
+{
+    public class HttpWebRequestWrapper : IHttpWebRequest
+    {
+        private readonly HttpWebRequest _innerRequest;
+
+        public HttpWebRequestWrapper(HttpWebRequest innerRequest)
+        {
+            _innerRequest = innerRequest;
+        }
+
+        #region Properties
+
+        public HttpWebRequest InnerRequest { get { return _innerRequest; } }
+        public bool AllowAutoRedirect { get { return _innerRequest.AllowAutoRedirect; } set { _innerRequest.AllowAutoRedirect = value; } }
+        public bool AllowWriteStreamBuffering { get { return _innerRequest.AllowWriteStreamBuffering; } set { _innerRequest.AllowWriteStreamBuffering = value; } }
+        public bool HaveResponse { get { return _innerRequest.HaveResponse; } }
+        public bool KeepAlive { get { return _innerRequest.KeepAlive; } set { _innerRequest.KeepAlive = value; } }
+        public bool Pipelined { get { return _innerRequest.Pipelined; } set { _innerRequest.Pipelined = value; } }
+        public bool PreAuthenticate { get { return _innerRequest.PreAuthenticate; } set { _innerRequest.PreAuthenticate = value; } }
+        public bool UnsafeAuthenticatedConnectionSharing { get { return _innerRequest.UnsafeAuthenticatedConnectionSharing; } set { _innerRequest.UnsafeAuthenticatedConnectionSharing = value; } }
+        public bool SendChunked { get { return _innerRequest.SendChunked; } set { _innerRequest.SendChunked = value; } }
+        public DecompressionMethods AutomaticDecompression { get { return _innerRequest.AutomaticDecompression; } set { _innerRequest.AutomaticDecompression = value; } }
+        public int MaximumResponseHeadersLength { get { return _innerRequest.MaximumResponseHeadersLength; } set { _innerRequest.MaximumResponseHeadersLength = value; } }
+        public X509CertificateCollection ClientCertificates { get { return _innerRequest.ClientCertificates; } set { _innerRequest.ClientCertificates = value; } }
+        public CookieContainer CookieContainer { get { return _innerRequest.CookieContainer; } set { _innerRequest.CookieContainer = value; } }
+        public bool SupportsCookieContainer { get { return true; } }
+        public Uri RequestUri { get { return _innerRequest.RequestUri; } }
+        public long ContentLength { get { return _innerRequest.ContentLength; } set { _innerRequest.ContentLength = value; } }
+        public int Timeout { get { return _innerRequest.Timeout; } set { _innerRequest.Timeout = value; } }
+        public int ReadWriteTimeout { get { return _innerRequest.ReadWriteTimeout; } set { _innerRequest.ReadWriteTimeout = value; } }
+        public Uri Address { get { return _innerRequest.Address; } }
+        public HttpContinueDelegate ContinueDelegate { get { return _innerRequest.ContinueDelegate; } set { _innerRequest.ContinueDelegate = value; } }
+        public ServicePoint ServicePoint { get { return _innerRequest.ServicePoint; } }
+        public string Host { get { return _innerRequest.Host; } set { _innerRequest.Host = value; } }
+        public int MaximumAutomaticRedirections { get { return _innerRequest.MaximumAutomaticRedirections; } set { _innerRequest.MaximumAutomaticRedirections = value; } }
+        public string Method { get { return _innerRequest.Method; } set { _innerRequest.Method = value; } }
+        public ICredentials Credentials { get { return _innerRequest.Credentials; } set { _innerRequest.Credentials = value; } }
+        public bool UseDefaultCredentials { get { return _innerRequest.UseDefaultCredentials; } set { _innerRequest.UseDefaultCredentials = value; } }
+        public string ConnectionGroupName { get { return _innerRequest.ConnectionGroupName; } set { _innerRequest.ConnectionGroupName = value; } }
+        public WebHeaderCollection Headers { get { return _innerRequest.Headers; } set { _innerRequest.Headers = value; } }
+        public IWebProxy Proxy { get { return _innerRequest.Proxy; } set { _innerRequest.Proxy = value; } }
+        public Version ProtocolVersion { get { return _innerRequest.ProtocolVersion; } set { _innerRequest.ProtocolVersion = value; } }
+        public string ContentType { get { return _innerRequest.ContentType; } set { _innerRequest.ContentType = value; } }
+        public string MediaType { get { return _innerRequest.MediaType; } set { _innerRequest.MediaType = value; } }
+        public string TransferEncoding { get { return _innerRequest.TransferEncoding; } set { _innerRequest.TransferEncoding = value; } }
+        public string Connection { get { return _innerRequest.Connection; } set { _innerRequest.Connection = value; } }
+        public string Accept { get { return _innerRequest.Accept; } set { _innerRequest.Accept = value; } }
+        public string Referer { get { return _innerRequest.Referer; } set { _innerRequest.Referer = value; } }
+        public string UserAgent { get { return _innerRequest.UserAgent; } set { _innerRequest.UserAgent = value; } }
+        public string Expect { get { return _innerRequest.Expect; } set { _innerRequest.Expect = value; } }
+        public DateTime IfModifiedSince { get { return _innerRequest.IfModifiedSince; } set { _innerRequest.IfModifiedSince = value; } }
+        public DateTime Date { get { return _innerRequest.Date; } set { _innerRequest.Date = value; } }
+        public RequestCachePolicy CachePolicy { get { return _innerRequest.CachePolicy; } set { _innerRequest.CachePolicy = value; } }
+        public AuthenticationLevel AuthenticationLevel { get { return _innerRequest.AuthenticationLevel; } set { _innerRequest.AuthenticationLevel = value; } }
+        public TokenImpersonationLevel ImpersonationLevel { get { return _innerRequest.ImpersonationLevel; } set { _innerRequest.ImpersonationLevel = value; } }
+
+        #endregion
+
+        #region Methods
+
+        public IAsyncResult BeginGetRequestStream(AsyncCallback callback, object state)
+        {
+            return _innerRequest.BeginGetRequestStream(callback, state);
+        }
+
+        public Stream EndGetRequestStream(IAsyncResult asyncResult)
+        {
+            return _innerRequest.EndGetRequestStream(asyncResult);
+        }
+
+        public Stream EndGetRequestStream(IAsyncResult asyncResult, out TransportContext context)
+        {
+            return _innerRequest.EndGetRequestStream(asyncResult, out context);
+        }
+
+        public Stream GetRequestStream()
+        {
+            return _innerRequest.GetRequestStream();
+        }
+
+        public Stream GetRequestStream(out TransportContext context)
+        {
+            return _innerRequest.GetRequestStream(out context);
+        }
+
+        public IAsyncResult BeginGetResponse(AsyncCallback callback, object state)
+        {
+            return _innerRequest.BeginGetResponse(callback, state);
+        }
+
+        public IHttpWebResponse EndGetResponse(IAsyncResult asyncResult)
+        {
+            return new HttpWebResponseWrapper((HttpWebResponse)_innerRequest.EndGetResponse(asyncResult));
+        }
+
+        public IHttpWebResponse GetResponse()
+        {
+            return new HttpWebResponseWrapper((HttpWebResponse)_innerRequest.GetResponse());
+        }
+
+        public void Abort()
+        {
+            _innerRequest.Abort();
+        }
+
+        public void AddRange(int @from, int to)
+        {
+            _innerRequest.AddRange(@from, to);
+        }
+
+        public void AddRange(long @from, long to)
+        {
+            _innerRequest.AddRange(@from, to);
+        }
+
+        public void AddRange(int range)
+        {
+            _innerRequest.AddRange(range);
+        }
+
+        public void AddRange(long range)
+        {
+            _innerRequest.AddRange(range);
+        }
+
+        public void AddRange(string rangeSpecifier, int @from, int to)
+        {
+            _innerRequest.AddRange(rangeSpecifier, @from, to);
+        }
+
+        public void AddRange(string rangeSpecifier, long @from, long to)
+        {
+            _innerRequest.AddRange(rangeSpecifier, @from, to);
+        }
+
+        public void AddRange(string rangeSpecifier, int range)
+        {
+            _innerRequest.AddRange(rangeSpecifier, range);
+        }
+
+        public void AddRange(string rangeSpecifier, long range)
+        {
+            _innerRequest.AddRange(rangeSpecifier, range);
+        }
+
+        public object GetLifetimeService()
+        {
+            return _innerRequest.GetLifetimeService();
+        }
+
+        public object InitializeLifetimeService()
+        {
+            return _innerRequest.InitializeLifetimeService();
+        }
+
+        public ObjRef CreateObjRef(Type requestedType)
+        {
+            return _innerRequest.CreateObjRef(requestedType);
+        }
+
+        #endregion
+    }
+}

--- a/src/EasyHttp/Http/Abstractions/HttpWebResponseWrapper.cs
+++ b/src/EasyHttp/Http/Abstractions/HttpWebResponseWrapper.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.Runtime.Remoting;
+using System.Runtime.Serialization;
+
+namespace EasyHttp.Http.Abstractions
+{
+    public class HttpWebResponseWrapper : IWebResponse, IHttpWebResponse
+    {
+        private readonly HttpWebResponse _innerResponse;
+
+        public HttpWebResponseWrapper(HttpWebResponse innerResponse)
+        {
+            _innerResponse = innerResponse;
+        }
+
+        public HttpWebResponse InnerResponse { get { return _innerResponse; } }
+        public bool IsMutuallyAuthenticated { get { return _innerResponse.IsMutuallyAuthenticated; } }
+        long IWebResponse.ContentLength { get; set; }
+        string IWebResponse.ContentType { get; set; }
+        public CookieCollection Cookies { get { return _innerResponse.Cookies; } set { _innerResponse.Cookies = value; } }
+        public WebHeaderCollection Headers { get { return _innerResponse.Headers; } }
+        public bool SupportsHeaders { get { return true; } }
+        public long ContentLength { get { return _innerResponse.ContentLength; } }
+        public string ContentEncoding { get { return _innerResponse.ContentEncoding; } }
+        public string ContentType { get { return _innerResponse.ContentType; } }
+        public string CharacterSet { get { return _innerResponse.CharacterSet; } }
+        public string Server { get { return _innerResponse.Server; } }
+        public DateTime LastModified { get { return _innerResponse.LastModified; } }
+        public HttpStatusCode StatusCode { get { return _innerResponse.StatusCode; } }
+        public string StatusDescription { get { return _innerResponse.StatusDescription; } }
+        public Version ProtocolVersion { get { return _innerResponse.ProtocolVersion; } }
+        public Uri ResponseUri { get { return _innerResponse.ResponseUri; } }
+        public string Method { get { return _innerResponse.Method; } }
+        public bool IsFromCache { get { return _innerResponse.IsFromCache; } }
+
+        public Stream GetResponseStream()
+        {
+            return _innerResponse.GetResponseStream();
+        }
+
+        public void Close()
+        {
+            _innerResponse.Close();
+        }
+
+        public string GetResponseHeader(string headerName)
+        {
+            return _innerResponse.GetResponseHeader(headerName);
+        }
+
+        public object GetLifetimeService()
+        {
+            return _innerResponse.GetLifetimeService();
+        }
+
+        public object InitializeLifetimeService()
+        {
+            return _innerResponse.InitializeLifetimeService();
+        }
+
+        public ObjRef CreateObjRef(Type requestedType)
+        {
+            return _innerResponse.CreateObjRef(requestedType);
+        }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            (_innerResponse as ISerializable).GetObjectData(info, context);
+        }
+
+        public void Dispose()
+        {
+            (_innerResponse as IDisposable).Dispose();
+        }
+    }
+}

--- a/src/EasyHttp/Http/Abstractions/IHttpRequestInterception.cs
+++ b/src/EasyHttp/Http/Abstractions/IHttpRequestInterception.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace EasyHttp.Http.Abstractions
+{
+    /// <summary>
+    /// Used by <see cref="HttpClient"/> to match against a <see cref="HttpRequest"/>
+    /// in the <code>HttpClient.ProcessRequst(...)</code>.
+    /// </summary>
+    public interface IHttpRequestInterception
+    {
+        /// <summary>
+        /// Used to identify when this interceptor should
+        /// override a particular <see cref="HttpRequest"/>
+        /// </summary>
+        /// <remarks>
+        /// Returns <code>true</code> when this iterceptor
+        /// should replace the given <see cref="HttpRequest"/>.
+        /// </remarks>
+        Func<HttpRequest, bool> Matches { get; }
+
+        /// <summary>
+        /// Builds the <see cref="IHttpWebResponse"/> to insert
+        /// into the <see cref="HttpResponse"/> for decoding.
+        /// </summary>
+        /// <returns>
+        /// A new <see cref="IHttpWebResponse"/> customized by calls
+        /// to the <see cref="IHttpRequestInterceptionBuilder"/>
+        /// interface.
+        /// </returns>
+        IHttpWebResponse GetInjectedResponse();
+    }
+}

--- a/src/EasyHttp/Http/Abstractions/IHttpRequestInterceptionBuilder.cs
+++ b/src/EasyHttp/Http/Abstractions/IHttpRequestInterceptionBuilder.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using System.Net;
+
+namespace EasyHttp.Http.Abstractions
+{
+    public interface IHttpRequestInterceptionBuilder
+    {
+        /// <summary>
+        /// Inject status code, a single Content-Type header, and a string response body.
+        /// </summary>
+        void InjectResponse(HttpStatusCode injectedResponseCode, string contentType, string injectedResponseBody);
+
+        /// <summary>
+        /// Inject status code, a dictionary of headers, and a string response body.
+        /// </summary>
+        void InjectResponse(HttpStatusCode injectedResponseCode, Dictionary<HttpResponseHeader, string> injectedResponseHeaders, string injectedResponseBody);
+
+        /// <summary>
+        /// Inject a fully mocked <see cref="IHttpWebResponse"/>.
+        /// </summary>
+        void InjectResponse(IHttpWebResponse response);
+    }
+}

--- a/src/EasyHttp/Http/Abstractions/IHttpWebRequest.cs
+++ b/src/EasyHttp/Http/Abstractions/IHttpWebRequest.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.Net.Cache;
+using System.Net.Security;
+using System.Runtime.Remoting;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Principal;
+
+namespace EasyHttp.Http.Abstractions
+{
+    public interface IHttpWebRequest
+    {
+        bool AllowAutoRedirect { get; set; }
+        bool AllowWriteStreamBuffering { get; set; }
+        bool HaveResponse { get; }
+        bool KeepAlive { get; set; }
+        bool Pipelined { get; set; }
+        bool PreAuthenticate { get; set; }
+        bool UnsafeAuthenticatedConnectionSharing { get; set; }
+        bool SendChunked { get; set; }
+        DecompressionMethods AutomaticDecompression { get; set; }
+        int MaximumResponseHeadersLength { get; set; }
+        X509CertificateCollection ClientCertificates { get; set; }
+        CookieContainer CookieContainer { get; set; }
+        bool SupportsCookieContainer { get; }
+        Uri RequestUri { get; }
+        long ContentLength { get; set; }
+        int Timeout { get; set; }
+        int ReadWriteTimeout { get; set; }
+        Uri Address { get; }
+        HttpContinueDelegate ContinueDelegate { get; set; }
+        ServicePoint ServicePoint { get; }
+        string Host { get; set; }
+        int MaximumAutomaticRedirections { get; set; }
+        string Method { get; set; }
+        ICredentials Credentials { get; set; }
+        bool UseDefaultCredentials { get; set; }
+        string ConnectionGroupName { get; set; }
+        WebHeaderCollection Headers { get; set; }
+        IWebProxy Proxy { get; set; }
+        Version ProtocolVersion { get; set; }
+        String ContentType { get; set; }
+        string MediaType { get; set; }
+        string TransferEncoding { get; set; }
+        string Connection { get; set; }
+        string Accept { get; set; }
+        string Referer { get; set; }
+        string UserAgent { get; set; }
+        string Expect { get; set; }
+        DateTime IfModifiedSince { get; set; }
+        DateTime Date { get; set; }
+        RequestCachePolicy CachePolicy { get; set; }
+        AuthenticationLevel AuthenticationLevel { get; set; }
+        TokenImpersonationLevel ImpersonationLevel { get; set; }
+        IAsyncResult BeginGetRequestStream(AsyncCallback callback, object state);
+        Stream EndGetRequestStream(IAsyncResult asyncResult);
+        Stream EndGetRequestStream(IAsyncResult asyncResult, out TransportContext context);
+        Stream GetRequestStream();
+        Stream GetRequestStream(out TransportContext context);
+        IAsyncResult BeginGetResponse(AsyncCallback callback, object state);
+        IHttpWebResponse EndGetResponse(IAsyncResult asyncResult);
+        IHttpWebResponse GetResponse();
+        void Abort();
+        void AddRange(int from, int to);
+        void AddRange(long from, long to);
+        void AddRange(int range);
+        void AddRange(long range);
+        void AddRange(string rangeSpecifier, int from, int to);
+        void AddRange(string rangeSpecifier, long from, long to);
+        void AddRange(string rangeSpecifier, int range);
+        void AddRange(string rangeSpecifier, long range);
+        object GetLifetimeService();
+        object InitializeLifetimeService();
+        ObjRef CreateObjRef(Type requestedType);
+    }
+}

--- a/src/EasyHttp/Http/Abstractions/IHttpWebResponse.cs
+++ b/src/EasyHttp/Http/Abstractions/IHttpWebResponse.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.Runtime.Remoting;
+
+namespace EasyHttp.Http.Abstractions
+{
+    public interface IHttpWebResponse
+    {
+        bool IsMutuallyAuthenticated { get; }
+        CookieCollection Cookies { get; set; }
+        WebHeaderCollection Headers { get; }
+        bool SupportsHeaders { get; }
+        long ContentLength { get; }
+        String ContentEncoding { get; }
+        string ContentType { get; }
+        string CharacterSet { get; }
+        string Server { get; }
+        DateTime LastModified { get; }
+        HttpStatusCode StatusCode { get; }
+        string StatusDescription { get; }
+        Version ProtocolVersion { get; }
+        Uri ResponseUri { get; }
+        string Method { get; }
+        bool IsFromCache { get; }
+        Stream GetResponseStream();
+        void Close();
+        string GetResponseHeader(string headerName);
+        object GetLifetimeService();
+        object InitializeLifetimeService();
+        ObjRef CreateObjRef(Type requestedType);
+    }
+}

--- a/src/EasyHttp/Http/Abstractions/IWebResponse.cs
+++ b/src/EasyHttp/Http/Abstractions/IWebResponse.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.Runtime.Remoting;
+using System.Runtime.Serialization;
+
+namespace EasyHttp.Http.Abstractions
+{
+    public interface IWebResponse : ISerializable, IDisposable
+    {
+        void Close();
+        bool IsFromCache { get; }
+        bool IsMutuallyAuthenticated { get; }
+        long ContentLength { get; set; }
+        string ContentType { get; set; }
+        Uri ResponseUri { get; }
+        WebHeaderCollection Headers { get; }
+        bool SupportsHeaders { get; }
+        Stream GetResponseStream();
+        object GetLifetimeService();
+        object InitializeLifetimeService();
+        ObjRef CreateObjRef(Type requestedType);
+    }
+}

--- a/src/EasyHttp/Http/Abstractions/WebResponseWrapper.cs
+++ b/src/EasyHttp/Http/Abstractions/WebResponseWrapper.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.Runtime.Remoting;
+using System.Runtime.Serialization;
+
+namespace EasyHttp.Http.Abstractions
+{
+    public class WebResponseWrapper : IWebResponse
+    {
+        private readonly WebResponse _innerRespose;
+
+        public WebResponseWrapper(WebResponse innerRespose)
+        {
+            _innerRespose = innerRespose;
+        }
+
+        public void Close()
+        {
+            _innerRespose.Close();
+        }
+
+        public bool IsFromCache { get { return _innerRespose.IsFromCache; } }
+        public bool IsMutuallyAuthenticated { get { return _innerRespose.IsMutuallyAuthenticated; } }
+        public long ContentLength { get { return _innerRespose.ContentLength; } set { _innerRespose.ContentLength = value; } }
+        public string ContentType { get { return _innerRespose.ContentType; } set { _innerRespose.ContentType = value; } }
+        public Uri ResponseUri { get { return _innerRespose.ResponseUri; } }
+        public WebHeaderCollection Headers { get { return _innerRespose.Headers; } }
+        public bool SupportsHeaders { get { return false; } }
+
+        public Stream GetResponseStream()
+        {
+            return _innerRespose.GetResponseStream();
+        }
+
+        public object GetLifetimeService()
+        {
+            return _innerRespose.GetLifetimeService();
+        }
+
+        public object InitializeLifetimeService()
+        {
+            return _innerRespose.InitializeLifetimeService();
+        }
+
+        public ObjRef CreateObjRef(Type requestedType)
+        {
+            return _innerRespose.CreateObjRef(requestedType);
+        }
+
+        public void Dispose()
+        {
+            (_innerRespose as IDisposable).Dispose();
+        }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            (_innerRespose as ISerializable).GetObjectData(info, context);
+        }
+    }
+}

--- a/src/EasyHttp/Http/HttpClient.cs
+++ b/src/EasyHttp/Http/HttpClient.cs
@@ -74,11 +74,11 @@ namespace EasyHttp.Http
         private bool _shouldRemoveAtSign = true;
         private readonly Func<string, HttpResponse> _getResponse;
 
-        public bool LoggingEnabled { get; set; }
-        public bool ThrowExceptionOnHttpError { get; set; }
-        public bool StreamResponse { get; set; }
+        public virtual bool LoggingEnabled { get; set; }
+        public virtual bool ThrowExceptionOnHttpError { get; set; }
+        public virtual bool StreamResponse { get; set; }
 
-        public bool ShouldRemoveAtSign
+        public virtual bool ShouldRemoveAtSign
         {
             get { return _shouldRemoveAtSign; }
             set
@@ -86,6 +86,10 @@ namespace EasyHttp.Http
                 _shouldRemoveAtSign = value;
                 _decoder.ShouldRemoveAtSign = value;
             }
+        }
+
+        public HttpClient() : this(null)
+        {
         }
 
         public HttpClient(Func<string,HttpResponse> getResponse = null):this(new DefaultEncoderDecoderConfiguration(), getResponse)
@@ -97,7 +101,7 @@ namespace EasyHttp.Http
         {
             _encoder = encoderDecoderConfiguration.GetEncoder();
             _decoder = encoderDecoderConfiguration.GetDecoder();
-            _decoder.ShouldRemoveAtSign = ShouldRemoveAtSign;
+            _decoder.ShouldRemoveAtSign = _shouldRemoveAtSign;
             _uriComposer = new UriComposer();
 
             Request = new HttpRequest(_encoder);
@@ -109,8 +113,8 @@ namespace EasyHttp.Http
             _baseUri = baseUri;
         }
 
-        public HttpResponse Response { get; private set; }
-        public HttpRequest Request { get; private set; }
+        public virtual HttpResponse Response { get; private set; }
+        public virtual HttpRequest Request { get; private set; }
 
         void InitRequest(string uri, HttpMethod method, object query)
         {
@@ -126,39 +130,39 @@ namespace EasyHttp.Http
         }
 
 
-        public HttpResponse GetAsFile(string uri, string filename)
+        public virtual HttpResponse GetAsFile(string uri, string filename)
         {
             InitRequest(uri, HttpMethod.GET, null);
             return ProcessRequest(filename);
         }
 
-        public HttpResponse Get(string uri, object query = null)
+        public virtual HttpResponse Get(string uri, object query = null)
         {
             InitRequest(uri, HttpMethod.GET, query);
             return ProcessRequest();
         }
 
-        public HttpResponse Options(string uri)
+        public virtual HttpResponse Options(string uri)
         {
             InitRequest(uri, HttpMethod.OPTIONS, null);
             return ProcessRequest();
         }
 
-        public HttpResponse Post(string uri, object data, string contentType, object query = null)
+        public virtual HttpResponse Post(string uri, object data, string contentType, object query = null)
         {
             InitRequest(uri, HttpMethod.POST, query);
             InitData(data, contentType);
             return ProcessRequest();
         }
 
-        public HttpResponse Patch(string uri, object data, string contentType, object query = null)
+        public virtual HttpResponse Patch(string uri, object data, string contentType, object query = null)
         {
             InitRequest(uri, HttpMethod.PATCH, query);
             InitData(data, contentType);
             return ProcessRequest();
         }
 
-        public HttpResponse Post(string uri, IDictionary<string, object> formData, IList<FileData> files, object query = null)
+        public virtual HttpResponse Post(string uri, IDictionary<string, object> formData, IList<FileData> files, object query = null)
         {
             InitRequest(uri, HttpMethod.POST, query);
             Request.MultiPartFormData = formData;
@@ -167,7 +171,7 @@ namespace EasyHttp.Http
             return ProcessRequest();
         }
 
-        public HttpResponse Put(string uri, object data, string contentType, object query = null)
+        public virtual HttpResponse Put(string uri, object data, string contentType, object query = null)
         {
             InitRequest(uri, HttpMethod.PUT, query);
             InitData(data, contentType);
@@ -183,20 +187,20 @@ namespace EasyHttp.Http
             }
         }
 
-        public HttpResponse Delete(string uri, object query = null)
+        public virtual HttpResponse Delete(string uri, object query = null)
         {
             InitRequest(uri, HttpMethod.DELETE, query);
             return ProcessRequest();
         }
 
 
-        public HttpResponse Head(string uri, object query = null)
+        public virtual HttpResponse Head(string uri, object query = null)
         {
             InitRequest(uri, HttpMethod.HEAD, query);
             return ProcessRequest();
         }
 
-        public HttpResponse PutFile(string uri, string filename, string contentType)
+        public virtual HttpResponse PutFile(string uri, string filename, string contentType)
         {
             InitRequest(uri, HttpMethod.PUT, null);
             Request.ContentType = contentType;
@@ -228,7 +232,7 @@ namespace EasyHttp.Http
             return response;
         }
 
-        public void AddClientCertificates(X509CertificateCollection certificates)
+        public virtual void AddClientCertificates(X509CertificateCollection certificates)
         {
             if(certificates == null || certificates.Count == 0)
                 return;

--- a/src/EasyHttp/Http/HttpClient.cs
+++ b/src/EasyHttp/Http/HttpClient.cs
@@ -1,10 +1,10 @@
 ﻿#region License
 // Distributed under the BSD License
 // =================================
-// 
+//
 // Copyright (c) 2010, Hadi Hariri
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
 //     * Redistributions of source code must retain the above copyright
@@ -15,7 +15,7 @@
 //     * Neither the name of Hadi Hariri nor the
 //       names of its contributors may be used to endorse or promote products
 //       derived from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -27,26 +27,26 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // =============================================================
-// 
-// 
+//
+//
 // Parts of this Software use JsonFX Serialization Library which is distributed under the MIT License:
-// 
+//
 // Distributed under the terms of an MIT-style license:
-// 
+//
 // The MIT License
-// 
+//
 // Copyright (c) 2006-2009 Stephen M. McKamey
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -91,7 +91,7 @@ namespace EasyHttp.Http
         public HttpClient(Func<string,HttpResponse> getResponse = null):this(new DefaultEncoderDecoderConfiguration(), getResponse)
         {
         }
-      
+
 
         public HttpClient(IEncoderDecoderConfiguration encoderDecoderConfiguration, Func<string, HttpResponse> getResponse = null)
         {
@@ -99,7 +99,7 @@ namespace EasyHttp.Http
             _decoder = encoderDecoderConfiguration.GetDecoder();
             _decoder.ShouldRemoveAtSign = ShouldRemoveAtSign;
             _uriComposer = new UriComposer();
-            
+
             Request = new HttpRequest(_encoder);
             _getResponse = getResponse ?? GetResponse;
         }
@@ -189,7 +189,7 @@ namespace EasyHttp.Http
             return ProcessRequest();
         }
 
- 
+
         public HttpResponse Head(string uri, object query = null)
         {
             InitRequest(uri, HttpMethod.HEAD, query);

--- a/src/EasyHttp/Http/HttpClient.cs
+++ b/src/EasyHttp/Http/HttpClient.cs
@@ -206,17 +206,24 @@ namespace EasyHttp.Http
 
         HttpResponse ProcessRequest(string filename = "")
         {
-            var httpWebRequest = Request.PrepareRequest();
+            Response = GetResponse(filename);
 
-            Response = new HttpResponse(_decoder);
-
-            Response.GetResponse(httpWebRequest, filename, StreamResponse);
-            
             if (ThrowExceptionOnHttpError && IsHttpError())
             {
                 throw new HttpException(Response.StatusCode, Response.StatusDescription);
             }
             return Response;
+        }
+
+        private HttpResponse GetResponse(string filename)
+        {
+            var httpWebRequest = Request.PrepareRequest();
+
+            var response = new HttpResponse(_decoder);
+
+            response.GetResponse(httpWebRequest, filename, StreamResponse);
+
+            return response;
         }
 
         public void AddClientCertificates(X509CertificateCollection certificates)

--- a/src/EasyHttp/Http/HttpClient.cs
+++ b/src/EasyHttp/Http/HttpClient.cs
@@ -72,6 +72,7 @@ namespace EasyHttp.Http
         readonly IDecoder _decoder;
         readonly UriComposer _uriComposer;
         private bool _shouldRemoveAtSign = true;
+        private readonly Func<string, HttpResponse> _getResponse;
 
         public bool LoggingEnabled { get; set; }
         public bool ThrowExceptionOnHttpError { get; set; }
@@ -87,12 +88,12 @@ namespace EasyHttp.Http
             }
         }
 
-        public HttpClient():this(new DefaultEncoderDecoderConfiguration())
+        public HttpClient(Func<string,HttpResponse> getResponse = null):this(new DefaultEncoderDecoderConfiguration(), getResponse)
         {
         }
       
 
-        public HttpClient(IEncoderDecoderConfiguration encoderDecoderConfiguration)
+        public HttpClient(IEncoderDecoderConfiguration encoderDecoderConfiguration, Func<string, HttpResponse> getResponse = null)
         {
             _encoder = encoderDecoderConfiguration.GetEncoder();
             _decoder = encoderDecoderConfiguration.GetDecoder();
@@ -100,9 +101,10 @@ namespace EasyHttp.Http
             _uriComposer = new UriComposer();
             
             Request = new HttpRequest(_encoder);
+            _getResponse = getResponse ?? GetResponse;
         }
 
-        public HttpClient(string baseUri): this(new DefaultEncoderDecoderConfiguration())
+        public HttpClient(string baseUri, Func<string,HttpResponse> getResponse = null): this(new DefaultEncoderDecoderConfiguration(), getResponse)
         {
             _baseUri = baseUri;
         }
@@ -206,7 +208,7 @@ namespace EasyHttp.Http
 
         HttpResponse ProcessRequest(string filename = "")
         {
-            Response = GetResponse(filename);
+            Response = _getResponse(filename);
 
             if (ThrowExceptionOnHttpError && IsHttpError())
             {

--- a/src/EasyHttp/Http/HttpRequest.cs
+++ b/src/EasyHttp/Http/HttpRequest.cs
@@ -1,10 +1,10 @@
 ﻿#region License
 
 // Distributed under the BSD License
-//   
+//
 // YouTrackSharp Copyright (c) 2010-2012, Hadi Hariri and Contributors
 // All rights reserved.
-//   
+//
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are met:
 //      * Redistributions of source code must retain the above copyright
@@ -15,11 +15,11 @@
 //      * Neither the name of Hadi Hariri nor the
 //         names of its contributors may be used to endorse or promote products
 //         derived from this software without specific prior written permission.
-//   
+//
 //   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 //   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-//   TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
-//   PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL 
+//   TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+//   PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
 //   <COPYRIGHTHOLDER> BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
 //   SPECIAL,EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
 //   LIMITED  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
@@ -27,7 +27,7 @@
 //   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 //   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 //   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//   
+//
 
 #endregion
 
@@ -248,9 +248,9 @@ namespace EasyHttp.Http
             using (var fileStream = new FileStream(PutFilename, FileMode.Open))
             {
                 httpWebRequest.ContentLength = fileStream.Length;
-                
+
                 var requestStream = httpWebRequest.GetRequestStream();
-                
+
                 var buffer = new byte[81982];
 
                 int bytesRead = fileStream.Read(buffer, 0, buffer.Length);
@@ -263,15 +263,15 @@ namespace EasyHttp.Http
             }
         }
 
-   
-       
+
+
         void SetupMultiPartBody()
         {
             var multiPartStreamer = new MultiPartStreamer(MultiPartFormData, MultiPartFileData);
 
             httpWebRequest.ContentType = multiPartStreamer.GetContentType();
             var contentLength = multiPartStreamer.GetContentLength();
-            
+
             if (contentLength > 0)
             {
                 httpWebRequest.ContentLength = contentLength;

--- a/src/EasyHttp/Http/HttpRequest.cs
+++ b/src/EasyHttp/Http/HttpRequest.cs
@@ -41,6 +41,7 @@ using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using EasyHttp.Codecs;
+using EasyHttp.Http.Abstractions;
 using EasyHttp.Infrastructure;
 
 namespace EasyHttp.Http
@@ -53,7 +54,7 @@ namespace EasyHttp.Http
         bool _forceBasicAuth;
         string _password;
         string _username;
-        HttpWebRequest httpWebRequest;
+        IHttpWebRequest httpWebRequest;
         CookieContainer cookieContainer;
 
         public HttpRequest(IEncoder encoder)
@@ -282,9 +283,9 @@ namespace EasyHttp.Http
         }
 
 
-        public virtual HttpWebRequest PrepareRequest()
+        public virtual IHttpWebRequest PrepareRequest()
         {
-            httpWebRequest = (HttpWebRequest) WebRequest.Create(Uri);
+            httpWebRequest = new HttpWebRequestWrapper((HttpWebRequest) WebRequest.Create(Uri));
             httpWebRequest.AllowAutoRedirect = AllowAutoRedirect;
             SetupHeader();
 

--- a/src/EasyHttp/Http/HttpRequest.cs
+++ b/src/EasyHttp/Http/HttpRequest.cs
@@ -74,48 +74,48 @@ namespace EasyHttp.Http
             AllowAutoRedirect = true;
         }
 
-        public bool DisableAutomaticCompression { get; set; }
-        public string Accept { get; set; }
-        public string AcceptCharSet { get; set; }
-        public string AcceptEncoding { get; set; }
-        public string AcceptLanguage { get; set; }
-        public bool KeepAlive { get; set; }
-        public X509CertificateCollection ClientCertificates { get; set; }
-        public string ContentLength { get; private set; }
-        public string ContentType { get; set; }
-        public string ContentEncoding { get; set; }
-        public CookieCollection Cookies { get; set; }
-        public DateTime Date { get; set; }
-        public bool Expect { get; set; }
-        public string From { get; set; }
-        public string Host { get; set; }
-        public string IfMatch { get; set; }
-        public DateTime IfModifiedSince { get; set; }
-        public string IfRange { get; set; }
-        public int MaxForwards { get; set; }
-        public string Referer { get; set; }
-        public int Range { get; set; }
-        public string UserAgent { get; set; }
-        public IDictionary<string, object> RawHeaders { get; private set; }
-        public HttpMethod Method { get; set; }
-        public object Data { get; set; }
-        public string Uri { get; set; }
-        public string PutFilename { get; set; }
-        public IDictionary<string, object> MultiPartFormData { get; set; }
-        public IList<FileData> MultiPartFileData { get; set; }
-        public int Timeout { get; set; }
-        public Boolean ParametersAsSegments { get; set; }
+        public virtual bool DisableAutomaticCompression { get; set; }
+        public virtual string Accept { get; set; }
+        public virtual string AcceptCharSet { get; set; }
+        public virtual string AcceptEncoding { get; set; }
+        public virtual string AcceptLanguage { get; set; }
+        public virtual bool KeepAlive { get; set; }
+        public virtual X509CertificateCollection ClientCertificates { get; set; }
+        public virtual string ContentLength { get; private set; }
+        public virtual string ContentType { get; set; }
+        public virtual string ContentEncoding { get; set; }
+        public virtual CookieCollection Cookies { get; set; }
+        public virtual DateTime Date { get; set; }
+        public virtual bool Expect { get; set; }
+        public virtual string From { get; set; }
+        public virtual string Host { get; set; }
+        public virtual string IfMatch { get; set; }
+        public virtual DateTime IfModifiedSince { get; set; }
+        public virtual string IfRange { get; set; }
+        public virtual int MaxForwards { get; set; }
+        public virtual string Referer { get; set; }
+        public virtual int Range { get; set; }
+        public virtual string UserAgent { get; set; }
+        public virtual IDictionary<string, object> RawHeaders { get; private set; }
+        public virtual HttpMethod Method { get; set; }
+        public virtual object Data { get; set; }
+        public virtual string Uri { get; set; }
+        public virtual string PutFilename { get; set; }
+        public virtual IDictionary<string, object> MultiPartFormData { get; set; }
+        public virtual IList<FileData> MultiPartFileData { get; set; }
+        public virtual int Timeout { get; set; }
+        public virtual Boolean ParametersAsSegments { get; set; }
 
-        public bool ForceBasicAuth
+        public virtual bool ForceBasicAuth
         {
             get { return _forceBasicAuth; }
             set { _forceBasicAuth = value; }
         }
 
-        public bool PersistCookies { get; set; }
-        public bool AllowAutoRedirect { get; set; }
+        public virtual bool PersistCookies { get; set; }
+        public virtual bool AllowAutoRedirect { get; set; }
 
-        public void SetBasicAuthentication(string username, string password)
+        public virtual void SetBasicAuthentication(string username, string password)
         {
             _username = username;
             _password = password;
@@ -198,7 +198,7 @@ namespace EasyHttp.Http
             return true;
         }
 
-        public void AddExtraHeader(string header, object value)
+        public virtual void AddExtraHeader(string header, object value)
         {
             if (value != null && !RawHeaders.ContainsKey(header))
             {
@@ -282,7 +282,7 @@ namespace EasyHttp.Http
         }
 
 
-        public HttpWebRequest PrepareRequest()
+        public virtual HttpWebRequest PrepareRequest()
         {
             httpWebRequest = (HttpWebRequest) WebRequest.Create(Uri);
             httpWebRequest.AllowAutoRedirect = AllowAutoRedirect;
@@ -319,22 +319,22 @@ namespace EasyHttp.Http
         }
 
 
-        public void SetCacheControlToNoCache()
+        public virtual void SetCacheControlToNoCache()
         {
             _cachePolicy = new HttpRequestCachePolicy(HttpRequestCacheLevel.NoCacheNoStore);
         }
 
-        public void SetCacheControlWithMaxAge(TimeSpan maxAge)
+        public virtual void SetCacheControlWithMaxAge(TimeSpan maxAge)
         {
             _cachePolicy = new HttpRequestCachePolicy(HttpCacheAgeControl.MaxAge, maxAge);
         }
 
-        public void SetCacheControlWithMaxAgeAndMaxStale(TimeSpan maxAge, TimeSpan maxStale)
+        public virtual void SetCacheControlWithMaxAgeAndMaxStale(TimeSpan maxAge, TimeSpan maxStale)
         {
             _cachePolicy = new HttpRequestCachePolicy(HttpCacheAgeControl.MaxAgeAndMaxStale, maxAge, maxStale);
         }
 
-        public void SetCacheControlWithMaxAgeAndMinFresh(TimeSpan maxAge, TimeSpan minFresh)
+        public virtual void SetCacheControlWithMaxAgeAndMinFresh(TimeSpan maxAge, TimeSpan minFresh)
         {
             _cachePolicy = new HttpRequestCachePolicy(HttpCacheAgeControl.MaxAgeAndMinFresh, maxAge, minFresh);
         }

--- a/src/EasyHttp/Http/HttpResponse.cs
+++ b/src/EasyHttp/Http/HttpResponse.cs
@@ -62,13 +62,14 @@ using System.Net;
 using System.Text;
 using EasyHttp.Codecs;
 using EasyHttp.Configuration;
+using EasyHttp.Http.Abstractions;
 
 namespace EasyHttp.Http
 {
     public class HttpResponse
     {
         readonly IDecoder _decoder;
-        HttpWebResponse _response;
+        IHttpWebResponse _response;
 
         public virtual string CharacterSet { get; private set; }
         public virtual string ContentType { get; private set; }
@@ -125,11 +126,11 @@ namespace EasyHttp.Http
 
 
 
-        public virtual void GetResponse(WebRequest request, string filename, bool streamResponse)
+        public virtual void GetResponse(IHttpWebRequest request, string filename, bool streamResponse)
         {
             try
             {
-                _response = (HttpWebResponse) request.GetResponse();
+                _response = request.GetResponse();
 
             }
             catch (WebException webException)
@@ -138,7 +139,7 @@ namespace EasyHttp.Http
                 {
                     throw;
                 }
-                _response = (HttpWebResponse) webException.Response;
+                _response = new HttpWebResponseWrapper((HttpWebResponse) webException.Response);
 
             }
 

--- a/src/EasyHttp/Http/HttpResponse.cs
+++ b/src/EasyHttp/Http/HttpResponse.cs
@@ -61,6 +61,7 @@ using System.IO;
 using System.Net;
 using System.Text;
 using EasyHttp.Codecs;
+using EasyHttp.Configuration;
 
 namespace EasyHttp.Http
 {
@@ -69,42 +70,42 @@ namespace EasyHttp.Http
         readonly IDecoder _decoder;
         HttpWebResponse _response;
 
-        public string CharacterSet { get; private set; }
-        public string ContentType { get; private set; }
-        public HttpStatusCode StatusCode { get; private set; }
-        public string StatusDescription { get; private set; }
-        public CookieCollection Cookies { get; private set; }
-        public int Age { get; private set; }
-        public HttpMethod[] Allow { get; private set; }
-        public CacheControl CacheControl { get; private set; }
-        public string ContentEncoding { get; private set; }
-        public string ContentLanguage { get; private set; }
-        public long ContentLength { get; private set; }
-        public string ContentLocation { get; private set; }
+        public virtual string CharacterSet { get; private set; }
+        public virtual string ContentType { get; private set; }
+        public virtual HttpStatusCode StatusCode { get; private set; }
+        public virtual string StatusDescription { get; private set; }
+        public virtual CookieCollection Cookies { get; private set; }
+        public virtual int Age { get; private set; }
+        public virtual HttpMethod[] Allow { get; private set; }
+        public virtual CacheControl CacheControl { get; private set; }
+        public virtual string ContentEncoding { get; private set; }
+        public virtual string ContentLanguage { get; private set; }
+        public virtual long ContentLength { get; private set; }
+        public virtual string ContentLocation { get; private set; }
         
         // TODO :This should be files
-        public string ContentDisposition { get; private set; }
+        public virtual string ContentDisposition { get; private set; }
         
-        public DateTime Date { get; private set; }
-        public string ETag { get; private set; }
-        public DateTime Expires { get; private set; }
-        public DateTime LastModified { get; private set; }
-        public string Location { get; private set; }
-        public CacheControl Pragma { get; private set; }
-        public string Server { get; private set; }
-        public WebHeaderCollection RawHeaders { get; private set; }
-        public Stream ResponseStream { get { return _response.GetResponseStream(); }
+        public virtual DateTime Date { get; private set; }
+        public virtual string ETag { get; private set; }
+        public virtual DateTime Expires { get; private set; }
+        public virtual DateTime LastModified { get; private set; }
+        public virtual string Location { get; private set; }
+        public virtual CacheControl Pragma { get; private set; }
+        public virtual string Server { get; private set; }
+        public virtual WebHeaderCollection RawHeaders { get; private set; }
+        public virtual Stream ResponseStream { get { return _response.GetResponseStream(); }
         }
 
 
-        public dynamic DynamicBody
+        public virtual dynamic DynamicBody
         {
             get { return _decoder.DecodeToDynamic(RawText, ContentType); }
         }
 
-        public string RawText { get; private set; }
+        public virtual string RawText { get; private set; }
 
-        public T StaticBody<T>(string overrideContentType = null)
+        public virtual T StaticBody<T>(string overrideContentType = null)
         {
             if (overrideContentType != null)
             {
@@ -113,14 +114,18 @@ namespace EasyHttp.Http
             return _decoder.DecodeToStatic<T>(RawText, ContentType);
         }
 
+        public HttpResponse() : this(null)
+        {
+        }
+
         public HttpResponse(IDecoder decoder)
         {
-            _decoder = decoder;
+            _decoder = decoder ?? new DefaultEncoderDecoderConfiguration().GetDecoder();
         }
 
        
 
-        public void GetResponse(WebRequest request, string filename, bool streamResponse)
+        public virtual void GetResponse(WebRequest request, string filename, bool streamResponse)
         {
             try
             {

--- a/src/EasyHttp/Http/HttpResponse.cs
+++ b/src/EasyHttp/Http/HttpResponse.cs
@@ -1,10 +1,10 @@
 ﻿#region License
 // Distributed under the BSD License
 // =================================
-// 
+//
 // Copyright (c) 2010, Hadi Hariri
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
 //     * Redistributions of source code must retain the above copyright
@@ -15,7 +15,7 @@
 //     * Neither the name of Hadi Hariri nor the
 //       names of its contributors may be used to endorse or promote products
 //       derived from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -27,26 +27,26 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // =============================================================
-// 
-// 
+//
+//
 // Parts of this Software use JsonFX Serialization Library which is distributed under the MIT License:
-// 
+//
 // Distributed under the terms of an MIT-style license:
-// 
+//
 // The MIT License
-// 
+//
 // Copyright (c) 2006-2009 Stephen M. McKamey
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -82,10 +82,10 @@ namespace EasyHttp.Http
         public virtual string ContentLanguage { get; private set; }
         public virtual long ContentLength { get; private set; }
         public virtual string ContentLocation { get; private set; }
-        
+
         // TODO :This should be files
         public virtual string ContentDisposition { get; private set; }
-        
+
         public virtual DateTime Date { get; private set; }
         public virtual string ETag { get; private set; }
         public virtual DateTime Expires { get; private set; }
@@ -123,7 +123,7 @@ namespace EasyHttp.Http
             _decoder = decoder ?? new DefaultEncoderDecoderConfiguration().GetDecoder();
         }
 
-       
+
 
         public virtual void GetResponse(WebRequest request, string filename, bool streamResponse)
         {
@@ -197,10 +197,10 @@ namespace EasyHttp.Http
             ContentDisposition = GetHeader("Content-Disposition");
             ETag = GetHeader("ETag");
             Location = GetHeader("Location");
-                
+
             if (!String.IsNullOrEmpty(GetHeader("Expires")))
             {
-                DateTime expires; 
+                DateTime expires;
                 if (DateTime.TryParse(GetHeader("Expires"), out expires))
                 {
                     Expires = expires;

--- a/src/EasyHttp/Http/Injection/HttpRequestInterception.cs
+++ b/src/EasyHttp/Http/Injection/HttpRequestInterception.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using EasyHttp.Http.Abstractions;
+
+namespace EasyHttp.Http.Injection
+{
+    public static class RequestPredicateExtensions
+    {
+        public static bool MatchesMethod(this HttpRequest request, HttpMethod method)
+        {
+            return request.Method == method;
+        }
+
+        public static bool MatchesMethodAndUrl(this HttpRequest request, HttpMethod method, string url)
+        {
+            return request.MatchesMethod(method) && request.Uri.Equals(url, StringComparison.InvariantCultureIgnoreCase);
+        }
+    }
+
+    public class HttpRequestInterception : IHttpRequestInterception, IHttpRequestInterceptionBuilder
+    {
+        private HttpStatusCode _statusCode;
+        private Dictionary<HttpResponseHeader, string> _responseHeaders;
+        private string _responseBody;
+        private IHttpWebResponse _response;
+
+        /// <inheritdoc />
+        public Func<HttpRequest, bool> Matches { get; private set; }
+
+        public HttpRequestInterception(Func<HttpRequest, bool> requestPredicate)
+        {
+            Matches = requestPredicate ?? (x => true);
+        }
+
+        public HttpRequestInterception(HttpMethod methodToIntercept)
+            : this(r => r.MatchesMethod(methodToIntercept))
+        {
+        }
+
+        public HttpRequestInterception(HttpMethod methodToIntercept, string url = null)
+            : this(r => r.MatchesMethodAndUrl(methodToIntercept, url))
+        {
+        }
+
+        /// <inheritdoc />
+        public void InjectResponse(HttpStatusCode injectedResponseCode, string contentType, string injectedResponseBody)
+        {
+            InjectResponse(
+                injectedResponseCode,
+                new Dictionary<HttpResponseHeader, string>
+                {
+                    {HttpResponseHeader.ContentType, contentType}
+                },
+                injectedResponseBody
+            );
+        }
+
+        /// <inheritdoc />
+        public void InjectResponse(HttpStatusCode injectedResponseCode, Dictionary<HttpResponseHeader, string> injectedResponseHeaders, string injectedResponseBody)
+        {
+            _statusCode = injectedResponseCode;
+            _responseHeaders = injectedResponseHeaders;
+            _responseBody = injectedResponseBody;
+        }
+
+        /// <inheritdoc />
+        public void InjectResponse(IHttpWebResponse response)
+        {
+            _response = response;
+        }
+
+        /// <inheritdoc />
+        public IHttpWebResponse GetInjectedResponse()
+        {
+            return _response ?? new StubbedHttpWebResponse(_statusCode, _responseHeaders, _responseBody);
+        }
+    }
+}

--- a/src/EasyHttp/Http/Injection/StubbedHttpWebRequest.cs
+++ b/src/EasyHttp/Http/Injection/StubbedHttpWebRequest.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.Net.Cache;
+using System.Net.Security;
+using System.Runtime.Remoting;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Principal;
+using EasyHttp.Http.Abstractions;
+
+namespace EasyHttp.Http.Injection
+{
+    internal class StubbedHttpWebRequest : IHttpWebRequest
+    {
+        private readonly HttpRequestInterception _matchingInterceptor;
+
+        public StubbedHttpWebRequest(HttpRequestInterception matchingInterceptor)
+        {
+            _matchingInterceptor = matchingInterceptor;
+        }
+
+        public bool AllowAutoRedirect { get; set; }
+        public bool AllowWriteStreamBuffering { get; set; }
+        public bool HaveResponse { get; private set; }
+        public bool KeepAlive { get; set; }
+        public bool Pipelined { get; set; }
+        public bool PreAuthenticate { get; set; }
+        public bool UnsafeAuthenticatedConnectionSharing { get; set; }
+        public bool SendChunked { get; set; }
+        public DecompressionMethods AutomaticDecompression { get; set; }
+        public int MaximumResponseHeadersLength { get; set; }
+        public X509CertificateCollection ClientCertificates { get; set; }
+        public CookieContainer CookieContainer { get; set; }
+        public bool SupportsCookieContainer { get; private set; }
+        public Uri RequestUri { get; private set; }
+        public long ContentLength { get; set; }
+        public int Timeout { get; set; }
+        public int ReadWriteTimeout { get; set; }
+        public Uri Address { get; private set; }
+        public HttpContinueDelegate ContinueDelegate { get; set; }
+        public ServicePoint ServicePoint { get; private set; }
+        public string Host { get; set; }
+        public int MaximumAutomaticRedirections { get; set; }
+        public string Method { get; set; }
+        public ICredentials Credentials { get; set; }
+        public bool UseDefaultCredentials { get; set; }
+        public string ConnectionGroupName { get; set; }
+        public WebHeaderCollection Headers { get; set; }
+        public IWebProxy Proxy { get; set; }
+        public Version ProtocolVersion { get; set; }
+        public string ContentType { get; set; }
+        public string MediaType { get; set; }
+        public string TransferEncoding { get; set; }
+        public string Connection { get; set; }
+        public string Accept { get; set; }
+        public string Referer { get; set; }
+        public string UserAgent { get; set; }
+        public string Expect { get; set; }
+        public DateTime IfModifiedSince { get; set; }
+        public DateTime Date { get; set; }
+        public RequestCachePolicy CachePolicy { get; set; }
+        public AuthenticationLevel AuthenticationLevel { get; set; }
+        public TokenImpersonationLevel ImpersonationLevel { get; set; }
+
+        public IAsyncResult BeginGetRequestStream(AsyncCallback callback, object state)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Stream EndGetRequestStream(IAsyncResult asyncResult)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Stream EndGetRequestStream(IAsyncResult asyncResult, out TransportContext context)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Stream GetRequestStream()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Stream GetRequestStream(out TransportContext context)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncResult BeginGetResponse(AsyncCallback callback, object state)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IHttpWebResponse EndGetResponse(IAsyncResult asyncResult)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IHttpWebResponse GetResponse()
+        {
+            return _matchingInterceptor.GetInjectedResponse();
+        }
+
+        public void Abort()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AddRange(int @from, int to)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AddRange(long @from, long to)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AddRange(int range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AddRange(long range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AddRange(string rangeSpecifier, int @from, int to)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AddRange(string rangeSpecifier, long @from, long to)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AddRange(string rangeSpecifier, int range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AddRange(string rangeSpecifier, long range)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object GetLifetimeService()
+        {
+            throw new NotImplementedException();
+        }
+
+        public object InitializeLifetimeService()
+        {
+            throw new NotImplementedException();
+        }
+
+        public ObjRef CreateObjRef(Type requestedType)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/EasyHttp/Http/Injection/StubbedHttpWebResponse.cs
+++ b/src/EasyHttp/Http/Injection/StubbedHttpWebResponse.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Runtime.Remoting;
+using EasyHttp.Http.Abstractions;
+
+namespace EasyHttp.Http.Injection
+{
+    public class StubbedHttpWebResponse : IHttpWebResponse
+    {
+        private readonly string _responseBody;
+
+        public bool IsMutuallyAuthenticated { get; private set; }
+        public CookieCollection Cookies { get; set; }
+        public WebHeaderCollection Headers { get; private set; }
+        public bool SupportsHeaders { get; private set; }
+        public long ContentLength { get { return _responseBody.Length; } }
+        public string ContentEncoding { get{ return Headers.Get("Content-Encoding"); } }
+        public string ContentType { get { return Headers.Get("Content-Type"); } }
+        public string CharacterSet { get; private set; }
+        public string Server { get; private set; }
+        public DateTime LastModified { get; private set; }
+        public HttpStatusCode StatusCode { get; private set; }
+        public string StatusDescription { get; private set; }
+        public Version ProtocolVersion { get; private set; }
+        public Uri ResponseUri { get; private set; }
+        public string Method { get; private set; }
+        public bool IsFromCache { get; private set; }
+
+        public StubbedHttpWebResponse(HttpStatusCode statusCode, Dictionary<HttpResponseHeader, string> responseHeaders, string responseBody)
+        {
+            StatusCode = statusCode;
+
+            Headers = new WebHeaderCollection();
+            if (responseHeaders != null)
+            {
+                foreach (var header in responseHeaders)
+                {
+                    Headers.Add(header.Key, header.Value);
+                }
+            }
+
+            _responseBody = responseBody;
+        }
+
+        public Stream GetResponseStream()
+        {
+            return _responseBody.ToStream();
+        }
+
+        public void Close()
+        {
+            // TODO
+        }
+
+        public string GetResponseHeader(string headerName)
+        {
+            return Headers.AllKeys.Contains(headerName)
+                ? string.Join(",", Headers.GetValues(headerName))
+                : string.Empty;
+        }
+
+        public object GetLifetimeService()
+        {
+            throw new NotImplementedException("TODO");
+        }
+
+        public object InitializeLifetimeService()
+        {
+            throw new NotImplementedException("TODO");
+        }
+
+        public ObjRef CreateObjRef(Type requestedType)
+        {
+            throw new NotImplementedException("TODO");
+        }
+    }
+}

--- a/src/EasyHttp/Http/StreamExtensions.cs
+++ b/src/EasyHttp/Http/StreamExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System.IO;
+
+namespace EasyHttp.Http.Abstractions
+{
+    public static class StreamExtensions
+    {
+        public static Stream ToStream(this string s)
+        {
+            var stream = new MemoryStream();
+            var writer = new StreamWriter(stream);
+            if (s != null)
+            {
+                writer.Write(s);
+                writer.Flush();
+            }
+            stream.Position = 0;
+            return stream;
+        }
+    }
+}


### PR DESCRIPTION
I came across a few scenarios where I wanted to mock or stub out the request or response and tried a few different ways of going about this.  

This PR marks the public members of `HttpClient`, `HttpRequest`, and `HttpResponse` as `virtual` so that they can be more easily customized by popular .NET mocking techniques:

````
            var injectedResponse = Substitute.For<HttpResponse>();
            injectedResponse.StatusCode.Returns(HttpStatusCode.NotFound);

            httpClient = Substitute.For<HttpClient>();
            httpClient.Get(Arg.Any<string>()).Returns(injectedResponse);
````

The specific use cases which drove this investigation involved navigating some coordinated use of `StaticBody<T>` and `DynamicBody` and included challenges deserializing and responding properly to a variety of different possible responses from the same API endpoint, hence the concept of Interceptors and Injecting a custom response into the processing pipeline:

````
            var injectedResponseBody =
@"{
    'name': 'Serenity',
    'class': 'Firefly',
    'crew': [
        'Mal',
        'Wash',
        'Zoe'
    ]
}";
            httpClient = new HttpClient();

            httpClient.OnRequest(r =>
                        r.Uri.Contains("localhost:16000")
                        && r.Method == HttpMethod.POST
                )
                .InjectResponse(
                    HttpStatusCode.BadRequest,
                    HttpContentTypes.ApplicationJson,
                    injectedResponseBody
                );

````

`OnRequest` is a new method takes an optional predicate condition and returns an interface which offers a few options for customizing the response.
