### PR TITLE
Fix V3117 warning from PVS-Studio Static Analyzer

### DIFF
--- a/src/EasyHttp/Http/HttpClient.cs
+++ b/src/EasyHttp/Http/HttpClient.cs
@@ -108,6 +108,7 @@ namespace EasyHttp.Http
             RegisteredInterceptions = new List<HttpRequestInterception>();
         }
 
+        [Obsolete]
         public HttpClient(string baseUri, Func<string,HttpResponse> getResponse = null): this(new DefaultEncoderDecoderConfiguration())
         {
             _baseUri = baseUri;


### PR DESCRIPTION
Hello. I'm a member of the Pinguem.ru competition on finding errors in
open source projects. A bug, found using PVS-Studio.

Warnings with medium priority:

[V3117](https://www.viva64.com/en/w/v3117) Constructor parameter 'getResponse' is not used. HttpClient.cs 111